### PR TITLE
Create cli tool to use signing algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .cursor/*
 
 docs/example-node-implementation.xml
+
+*.keys.json
+keys.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +448,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "concurrent-queue"
@@ -977,6 +1073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "ondc-bap"
 version = "0.1.0"
 dependencies = [
@@ -1609,6 +1723,25 @@ dependencies = [
  "subtle",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "ondc-crypto-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "clap",
+ "hex",
+ "ondc-crypto-algorithms",
+ "ondc-crypto-formats",
+ "ondc-crypto-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2561,6 +2694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,6 +3216,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "ondc-crypto-traits",
     "ondc-crypto-algorithms", 
     "ondc-crypto-formats",
+    "ondc-crypto-cli",
 ]
 
 resolver = "2"

--- a/ondc-bap/config/staging.toml
+++ b/ondc-bap/config/staging.toml
@@ -21,8 +21,8 @@ max_retries = 3
 
 [keys]
 # These should be replaced with actual keys in production
-signing_private_key = "your-signing-private-key-base64"
-encryption_private_key = "your-encryption-private-key-base64"
+signing_private_key = "iblY/8ruRp43aGEjuCtJrs5QyAhaHroQIaUgWKNScco="
+encryption_private_key = "CeBWrM0FhC47Zek6QKCMopzNFC5U3JizkOuDYVqUXno="
 unique_key_id = "key_1"
 
 [security]

--- a/ondc-crypto-cli/Cargo.toml
+++ b/ondc-crypto-cli/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "ondc-crypto-cli"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ONDC cryptographic CLI utilities"
+keywords = ["ondc", "crypto", "cli", "keys", "signing"]
+categories = ["command-line-utilities", "cryptography"]
+
+[dependencies]
+# Internal workspace dependencies
+ondc-crypto-algorithms = { path = "../ondc-crypto-algorithms" }
+ondc-crypto-formats = { path = "../ondc-crypto-formats" }
+ondc-crypto-traits = { path = "../ondc-crypto-traits" }
+
+# CLI framework
+clap = { version = "4.0", features = ["derive"] }
+
+# Error handling
+anyhow.workspace = true
+thiserror.workspace = true
+
+# Random number generation
+rand.workspace = true
+
+# Output formatting
+serde_json.workspace = true
+serde.workspace = true
+base64.workspace = true
+hex.workspace = true
+
+# Logging
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[[bin]]
+name = "ondc-crypto"
+path = "src/main.rs"
+
+[features]
+default = []
+dev-deps = [] 

--- a/ondc-crypto-cli/README.md
+++ b/ondc-crypto-cli/README.md
@@ -1,0 +1,35 @@
+# ONDC Crypto CLI
+
+A command-line interface for ONDC cryptographic operations.
+
+## Features
+
+- Generate Ed25519 and X25519 key pairs
+- Sign data with Ed25519
+- Verify Ed25519 signatures
+- Hash data with BLAKE2
+- Multiple output formats (Base64, Hex, Raw)
+- JSON output support
+
+## Usage
+
+### Generate Keys
+```bash
+ondc-crypto generate ed25519
+ondc-crypto generate x25519 --format hex --json
+```
+
+### Sign Data
+```bash
+ondc-crypto sign --private-key <key> --data "Hello World"
+```
+
+### Verify Signatures
+```bash
+ondc-crypto verify --public-key <key> --signature <sig> --data "Hello World"
+```
+
+### Hash Data
+```bash
+ondc-crypto hash --data "Hello World"
+``` 

--- a/ondc-crypto-cli/examples/demo.sh
+++ b/ondc-crypto-cli/examples/demo.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+echo "=== ONDC Crypto CLI Demo ==="
+echo
+
+# Generate Ed25519 keys
+echo "1. Generating Ed25519 key pair..."
+cargo run --package ondc-crypto-cli -- generate ed25519 --json > ed25519.keys.json
+echo "Keys saved to ed25519.keys.json"
+echo
+
+# Generate X25519 keys
+echo "2. Generating X25519 key pair..."
+cargo run --package ondc-crypto-cli -- generate x25519 --json > x25519.keys.json
+echo "Keys saved to x25519.keys.json"
+echo
+
+# Extract keys for signing
+PRIVATE_KEY=$(jq -r .private_key ed25519.keys.json)
+PUBLIC_KEY=$(jq -r .public_key ed25519.keys.json)
+
+echo "3. Signing a message..."
+MESSAGE="Hello, ONDC World!"
+echo "Message: $MESSAGE"
+SIGNATURE=$(cargo run --package ondc-crypto-cli -- sign --private-key "$PRIVATE_KEY" --data "$MESSAGE")
+echo "Signature: $SIGNATURE"
+echo
+
+echo "4. Verifying the signature..."
+cargo run --package ondc-crypto-cli -- verify --public-key "$PUBLIC_KEY" --signature "$SIGNATURE" --data "$MESSAGE"
+echo
+
+echo "5. Testing invalid signature..."
+MODIFIED_MESSAGE="Hello, ONDC World! (modified)"
+echo "Modified message: $MODIFIED_MESSAGE"
+cargo run --package ondc-crypto-cli -- verify --public-key "$PUBLIC_KEY" --signature "$SIGNATURE" --data "$MODIFIED_MESSAGE" || echo "Expected failure for modified message"
+echo
+
+echo "6. Different output formats..."
+echo "Base64 format:"
+cargo run --package ondc-crypto-cli -- generate ed25519 --format base64 | head -2
+echo
+
+echo "Hex format:"
+cargo run --package ondc-crypto-cli -- generate ed25519 --format hex | head -2
+echo
+
+echo "=== Demo Complete ===" 

--- a/ondc-crypto-cli/src/main.rs
+++ b/ondc-crypto-cli/src/main.rs
@@ -1,0 +1,270 @@
+use clap::{Parser, Subcommand};
+use ondc_crypto_algorithms::prelude::*;
+use ondc_crypto_formats::prelude::*;
+use ondc_crypto_traits::traits::{Signer, Verifier, Hasher};
+use std::io::{self, Read};
+
+#[derive(Parser)]
+#[command(name = "ondc-crypto")]
+#[command(about = "ONDC Cryptographic CLI Utilities")]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate cryptographic keys
+    Generate {
+        /// Type of key to generate
+        #[arg(value_enum)]
+        key_type: KeyType,
+        
+        /// Output format for the keys
+        #[arg(short, long, value_enum, default_value_t = OutputFormat::Base64)]
+        format: OutputFormat,
+        
+        /// Output to JSON format
+        #[arg(short, long)]
+        json: bool,
+    },
+    
+    /// Sign data with Ed25519
+    Sign {
+        /// Private key in base64 format
+        #[arg(short, long)]
+        private_key: String,
+        
+        /// Data to sign (if not provided, reads from stdin)
+        #[arg(short, long)]
+        data: Option<String>,
+        
+        /// Output format for the signature
+        #[arg(short, long, value_enum, default_value_t = OutputFormat::Base64)]
+        format: OutputFormat,
+    },
+    
+    /// Verify Ed25519 signature
+    Verify {
+        /// Public key in base64 format
+        #[arg(short, long)]
+        public_key: String,
+        
+        /// Signature to verify
+        #[arg(short, long)]
+        signature: String,
+        
+        /// Data that was signed (if not provided, reads from stdin)
+        #[arg(short, long)]
+        data: Option<String>,
+    },
+    
+    /// Hash data with BLAKE2
+    Hash {
+        /// Data to hash (if not provided, reads from stdin)
+        #[arg(short, long)]
+        data: Option<String>,
+        
+        /// Output format for the hash
+        #[arg(short, long, value_enum, default_value_t = OutputFormat::Hex)]
+        format: OutputFormat,
+    },
+}
+
+#[derive(clap::ValueEnum, Clone)]
+enum KeyType {
+    Ed25519,
+    X25519,
+}
+
+#[derive(clap::ValueEnum, Clone)]
+enum OutputFormat {
+    Base64,
+    Hex,
+    Raw,
+}
+
+#[derive(serde::Serialize)]
+struct KeyPairOutput {
+    private_key: String,
+    public_key: String,
+    key_type: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    // Initialize logging
+    tracing_subscriber::fmt::init();
+    
+    let cli = Cli::parse();
+    
+    match cli.command {
+        Commands::Generate { key_type, format, json } => {
+            generate_keys(key_type, format, json)?;
+        }
+        Commands::Sign { private_key, data, format } => {
+            sign_data(private_key, data, format)?;
+        }
+        Commands::Verify { public_key, signature, data } => {
+            verify_signature(public_key, signature, data)?;
+        }
+        Commands::Hash { data, format } => {
+            hash_data(data, format)?;
+        }
+    }
+    
+    Ok(())
+}
+
+fn generate_keys(key_type: KeyType, format: OutputFormat, json: bool) -> anyhow::Result<()> {
+    match key_type {
+        KeyType::Ed25519 => {
+            let signer = Ed25519Signer::generate()?;
+            let private_key = signer.private_key();
+            let public_key = signer.public_key();
+            
+            let private_key_str = format_key(private_key, &format);
+            let public_key_str = format_key(&public_key, &format);
+            
+            if json {
+                let key_pair = KeyPairOutput {
+                    private_key: private_key_str,
+                    public_key: public_key_str,
+                    key_type: "Ed25519".to_string(),
+                };
+                println!("{}", serde_json::to_string_pretty(&key_pair)?);
+            } else {
+                println!("Ed25519 Key Pair:");
+                println!("Private Key: {}", private_key_str);
+                println!("Public Key:  {}", public_key_str);
+            }
+        }
+        KeyType::X25519 => {
+            let key_exchange = X25519KeyExchange::generate()?;
+            let private_key = key_exchange.private_key();
+            let public_key = key_exchange.public_key();
+            
+            let private_key_str = format_key(private_key, &format);
+            let public_key_str = format_key(&public_key, &format);
+            
+            if json {
+                let key_pair = KeyPairOutput {
+                    private_key: private_key_str,
+                    public_key: public_key_str,
+                    key_type: "X25519".to_string(),
+                };
+                println!("{}", serde_json::to_string_pretty(&key_pair)?);
+            } else {
+                println!("X25519 Key Pair:");
+                println!("Private Key: {}", private_key_str);
+                println!("Public Key:  {}", public_key_str);
+            }
+        }
+    }
+    
+    Ok(())
+}
+
+fn sign_data(private_key: String, data: Option<String>, format: OutputFormat) -> anyhow::Result<()> {
+    // Decode private key
+    let private_key_bytes = ed25519_private_key_from_base64(&private_key)?;
+    let signer = Ed25519Signer::new(&private_key_bytes)?;
+    
+    // Get data to sign
+    let data_to_sign = if let Some(data) = data {
+        data.into_bytes()
+    } else {
+        let mut buffer = Vec::new();
+        io::stdin().read_to_end(&mut buffer)?;
+        buffer
+    };
+    
+    // Sign the data
+    let signature = signer.sign(&data_to_sign)?;
+    let signature_str = format_signature(&signature, &format);
+    
+    println!("{}", signature_str);
+    Ok(())
+}
+
+fn verify_signature(public_key: String, signature: String, data: Option<String>) -> anyhow::Result<()> {
+    // Decode public key
+    let public_key_bytes = ed25519_public_key_from_base64(&public_key)?;
+    let verifier = Ed25519Verifier::new();
+    
+    // Decode signature
+    let signature_bytes = decode_signature(&signature)?;
+    
+    // Get data that was signed
+    let data_to_verify = if let Some(data) = data {
+        data.into_bytes()
+    } else {
+        let mut buffer = Vec::new();
+        io::stdin().read_to_end(&mut buffer)?;
+        buffer
+    };
+    
+    // Convert public key to fixed-size array
+    let mut public_key_array = [0u8; 32];
+    public_key_array.copy_from_slice(&public_key_bytes);
+    
+    // Convert signature to fixed-size array
+    let mut signature_array = [0u8; 64];
+    signature_array.copy_from_slice(&signature_bytes);
+    
+    // Verify the signature
+    match verifier.verify(&public_key_array, &data_to_verify, &signature_array) {
+        Ok(_) => {
+            println!("✓ Signature is valid");
+            std::process::exit(0);
+        }
+        Err(_) => {
+            eprintln!("✗ Signature is invalid");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn hash_data(data: Option<String>, format: OutputFormat) -> anyhow::Result<()> {
+    let hasher = Blake2Hasher::new();
+    
+    // Get data to hash
+    let data_to_hash = if let Some(data) = data {
+        data.into_bytes()
+    } else {
+        let mut buffer = Vec::new();
+        io::stdin().read_to_end(&mut buffer)?;
+        buffer
+    };
+    
+    // Hash the data
+    let hash = hasher.hash(&data_to_hash)?;
+    let hash_str = format_hash(&hash, &format);
+    
+    println!("{}", hash_str);
+    Ok(())
+}
+
+fn format_key(key: &[u8], format: &OutputFormat) -> String {
+    match format {
+        OutputFormat::Base64 => base64::encode(key),
+        OutputFormat::Hex => hex::encode(key),
+        OutputFormat::Raw => String::from_utf8_lossy(key).to_string(),
+    }
+}
+
+fn format_signature(signature: &[u8], format: &OutputFormat) -> String {
+    match format {
+        OutputFormat::Base64 => encode_signature(signature),
+        OutputFormat::Hex => hex::encode(signature),
+        OutputFormat::Raw => String::from_utf8_lossy(signature).to_string(),
+    }
+}
+
+fn format_hash(hash: &[u8], format: &OutputFormat) -> String {
+    match format {
+        OutputFormat::Base64 => base64::encode(hash),
+        OutputFormat::Hex => hex::encode(hash),
+        OutputFormat::Raw => String::from_utf8_lossy(hash).to_string(),
+    }
+} 


### PR DESCRIPTION
This pull request introduces a new `ondc-crypto-cli` package to the ONDC project, providing a command-line interface for cryptographic operations such as key generation, signing, verification, and hashing. It also includes updates to the workspace configuration and example usage scripts. Below are the key changes grouped by theme:

### Addition of `ondc-crypto-cli` Package
* Added a new `ondc-crypto-cli` package to the workspace, defined in `Cargo.toml`, with dependencies on existing ONDC crypto libraries and external libraries like `clap` for CLI functionality. (`Cargo.toml`, `ondc-crypto-cli/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R7) [[2]](diffhunk://#diff-68423b858c856d325b8b089b29fe6e71d62aa823fe72388ae9c227436db9f6a4R1-R44)
* Implemented the CLI functionality in `ondc-crypto-cli/src/main.rs`, supporting commands for key generation, signing, verification, and hashing with multiple output formats (Base64, Hex, Raw). (`ondc-crypto-cli/src/main.rs`)

### Documentation and Examples
* Added a `README.md` for `ondc-crypto-cli` documenting its features, commands, and usage examples. (`ondc-crypto-cli/README.md`)
* Included a demo script (`examples/demo.sh`) showcasing the CLI's capabilities, including key generation, signing, and verification workflows. (`ondc-crypto-cli/examples/demo.sh`)

### Configuration Updates
* Updated the workspace `Cargo.toml` to include the new `ondc-crypto-cli` package. (`Cargo.toml`)
* Replaced placeholder private keys in `ondc-bap/config/staging.toml` with example keys for staging purposes. (`ondc-bap/config/staging.toml`)